### PR TITLE
Pass on kwargs to `reader.tile`

### DIFF
--- a/rio_tiler_pds/cbers.py
+++ b/rio_tiler_pds/cbers.py
@@ -232,5 +232,5 @@ def tile(
 
     addresses = [f"{cbers_prefix}_BAND{band}.tif" for band in bands]
     return reader.multi_tile(
-        addresses, tile_x, tile_y, tile_z, tilesize=tilesize, nodata=0
+        addresses, tile_x, tile_y, tile_z, tilesize=tilesize, nodata=0, **kwargs
     )

--- a/rio_tiler_pds/landsat8.py
+++ b/rio_tiler_pds/landsat8.py
@@ -337,6 +337,7 @@ def tile(
                 tilesize=tilesize,
                 nodata=nodata,
                 resampling_method=resamp,
+                **kwargs
             )
 
         return tile, mask

--- a/rio_tiler_pds/sentinel2.py
+++ b/rio_tiler_pds/sentinel2.py
@@ -272,5 +272,5 @@ def tile(
 
     addresses = [f"{sentinel_prefix}/{band}.jp2" for band in bands]
     return reader.multi_tile(
-        addresses, tile_x, tile_y, tile_z, tilesize=tilesize, nodata=0
+        addresses, tile_x, tile_y, tile_z, tilesize=tilesize, nodata=0, **kwargs
     )


### PR DESCRIPTION
`kwargs` is accepted in the top-level `tile` functions but not passed on.