### PR TITLE
Fix sentinel 2 sceneid parser for single-digit UTM zones

### DIFF
--- a/rio_tiler_pds/sentinel/utils.py
+++ b/rio_tiler_pds/sentinel/utils.py
@@ -48,14 +48,14 @@ def s2_sceneid_parser(sceneid: str) -> Dict:
         )
 
     elif re.match(
-        "^S2[AB]_[0-9]{2}[A-Z]{3}_[0-9]{8}_[0-9]_L[0-2][A-C]$", sceneid
+        "^S2[AB]_[0-9]{1,2}[A-Z]{3}_[0-9]{8}_[0-9]_L[0-2][A-C]$", sceneid
     ):  # New sceneid format
         pattern = (
             r"^S"
             r"(?P<sensor>\w{1})"
             r"(?P<satellite>[AB]{1})"
             r"_"
-            r"(?P<utm>[0-9]{2})"
+            r"(?P<utm>[0-9]{1,2})"
             r"(?P<lat>\w{1})"
             r"(?P<sq>\w{2})"
             r"_"

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -403,7 +403,7 @@ def test_sentinel_newid_valid_single_digit_utm():
         "_day": "2",
         "_levelLow": "l2a",
     }
-    assert s2_sceneid_parser('S2B_2CMA_20181002_0_L2A') == expected_content
+    assert s2_sceneid_parser("S2B_2CMA_20181002_0_L2A") == expected_content
 
 
 def test_sentinel_newidl2a_valid():

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -383,6 +383,29 @@ def test_sentinel_newid_valid():
     assert s2_sceneid_parser(SENTINEL_SCENE_L1) == expected_content
 
 
+def test_sentinel_newid_valid_single_digit_utm():
+    """Parse sentinel-2 valid sceneid and return metadata for single-digit UTM zone."""
+    expected_content = {
+        "sensor": "2",
+        "satellite": "B",
+        "processingLevel": "L2A",
+        "acquisitionYear": "2018",
+        "acquisitionMonth": "10",
+        "acquisitionDay": "02",
+        "utm": "2",
+        "lat": "C",
+        "sq": "MA",
+        "num": "0",
+        "scene": "S2B_2CMA_20181002_0_L2A",
+        "date": "2018-10-02",
+        "_utm": "2",
+        "_month": "10",
+        "_day": "2",
+        "_levelLow": "l2a",
+    }
+    assert s2_sceneid_parser('S2B_2CMA_20181002_0_L2A') == expected_content
+
+
 def test_sentinel_newidl2a_valid():
     """Parse sentinel-2 valid sceneid and return metadata."""
     expected_content = {


### PR DESCRIPTION
With `sceneid`s in the `sentinel-cogs` bucket, scene ids for single-digit UTM zones don't have a leading `0`, e.g. `S2B_2CMA_20181002_0_L2A`, which fails with the current regex.