### PR TITLE
Fix sentinel 2 sceneid parser for double-digit revisits

### DIFF
--- a/rio_tiler_pds/sentinel/utils.py
+++ b/rio_tiler_pds/sentinel/utils.py
@@ -27,7 +27,7 @@ def s2_sceneid_parser(sceneid: str) -> Dict:
 
     """
     if re.match(
-        "^S2[AB]_L[0-2][A-C]_[0-9]{8}_[0-9]{2}[A-Z]{3}_[0-9]$", sceneid
+        "^S2[AB]_L[0-2][A-C]_[0-9]{8}_[0-9]{2}[A-Z]{3}_[0-9]{1,2}$", sceneid
     ):  # Legacy sceneid format
         pattern = (
             r"^S"
@@ -44,11 +44,11 @@ def s2_sceneid_parser(sceneid: str) -> Dict:
             r"(?P<lat>\w{1})"
             r"(?P<sq>\w{2})"
             r"_"
-            r"(?P<num>[0-9]{1})$"
+            r"(?P<num>[0-9]{1,2})$"
         )
 
     elif re.match(
-        "^S2[AB]_[0-9]{2}[A-Z]{3}_[0-9]{8}_[0-9]_L[0-2][A-C]$", sceneid
+        "^S2[AB]_[0-9]{2}[A-Z]{3}_[0-9]{8}_[0-9]{1,2}_L[0-2][A-C]$", sceneid
     ):  # New sceneid format
         pattern = (
             r"^S"
@@ -63,7 +63,7 @@ def s2_sceneid_parser(sceneid: str) -> Dict:
             r"(?P<acquisitionMonth>[0-9]{2})"
             r"(?P<acquisitionDay>[0-9]{2})"
             r"_"
-            r"(?P<num>[0-9]{1})"
+            r"(?P<num>[0-9]{1,2})"
             r"_"
             r"(?P<processingLevel>L[0-2][ABC])$"
         )

--- a/tests/test_sentinel2.py
+++ b/tests/test_sentinel2.py
@@ -406,6 +406,29 @@ def test_sentinel_newidl2a_valid():
     assert s2_sceneid_parser(SENTINEL_SCENE_L2) == expected_content
 
 
+def test_sentinel_newidl2a_valid_double_digit_revisit():
+    """Parse sentinel-2 valid sceneid and return metadata."""
+    expected_content = {
+        "sensor": "2",
+        "satellite": "B",
+        "processingLevel": "L2A",
+        "acquisitionYear": "2019",
+        "acquisitionMonth": "05",
+        "acquisitionDay": "07",
+        "utm": "22",
+        "lat": "X",
+        "sq": "DL",
+        "num": "10",
+        "scene": "S2B_22XDL_20190507_10_L2A",
+        "date": "2019-05-07",
+        "_utm": "22",
+        "_month": "5",
+        "_day": "7",
+        "_levelLow": "l2a",
+    }
+    assert s2_sceneid_parser("S2B_22XDL_20190507_10_L2A") == expected_content
+
+
 def test_sentinel_cogid_valid():
     """Parse sentinel-2 COG id valid sceneid and return metadata."""
     expected_content = {


### PR DESCRIPTION
The `sceneid` `S2B_22XDL_20190507_10_L2A` exists, which has ~~10~~ 11, since numbering starts at 0, revisits in a day, which fails with the current regex.